### PR TITLE
fix: use exact extension matching for no-compression file types

### DIFF
--- a/UZIP.js
+++ b/UZIP.js
@@ -415,7 +415,7 @@ var UZIP = {};
 		return data.buffer;
 	}
 	// no need to compress .PNG, .ZIP, .JPEG ....
-	function _noNeed(fn) {  var ext = fn.split(".").pop().toLowerCase();  return "png,jpg,jpeg,zip".indexOf(ext)!=-1;  }
+	function _noNeed(fn) {  var ext = fn.split(".").pop().toLowerCase();  return ["png","jpg","jpeg","zip"].indexOf(ext)!=-1;  }
 
 	function _writeHeader(data, o, p, obj, t, roff)
 	{


### PR DESCRIPTION
Thank you for creating this library. I think this is the best zip library. Very lightweight and zero dependencies!
While porting this library to Typescript and ESM modules for my react-native app. I find few bugs. I just wanted to send these fixes upstream i.e. the original library UZIP.js

## Summary

This changes `_noNeed(fn)` function checks extensions explicitly instead of doing substring matching against a comma-separated string.

```diff
-return "png,jpg,jpeg,zip".indexOf(ext)!=-1;
+return ["png","jpg","jpeg","zip"].indexOf(ext)!=-1;
```

## Why this is needed?

The current code uses substring matching, which can return true for values that are not real extensions in the allowlist.

Examples:

- `ext === "jp"` matches because `"jpg"` contains `"jp"`
- `ext === "ng"` matches because `"png"` contains `"ng"`
- `ext === "peg"` matches because `"jpeg"` contains `"peg"`
- `ext === ""` also matches because every string contains the empty string

That means some unrelated files can be treated as “do not compress” even though they should be compressed.

## Example behavior

Expected behavior after this change:

- `image.png` -> stored without compression
- `photo.jpg` -> stored without compression
- `archive.zip` -> stored without compression
- `file.jp` -> compressed
- `file.ng` -> compressed
- `note.txt` -> compressed